### PR TITLE
fix failing install

### DIFF
--- a/66-mirics.rules
+++ b/66-mirics.rules
@@ -1,0 +1,5 @@
+SUBSYSTEM=="usb",ENV{DEVTYPE}=="usb_device",ATTRS{idVendor}=="1df7",ATTRS{idProduct}=="2500",MODE:="0666"
+SUBSYSTEM=="usb",ENV{DEVTYPE}=="usb_device",ATTRS{idVendor}=="1df7",ATTRS{idProduct}=="3000",MODE:="0666"
+SUBSYSTEM=="usb",ENV{DEVTYPE}=="usb_device",ATTRS{idVendor}=="1df7",ATTRS{idProduct}=="3010",MODE:="0666"
+SUBSYSTEM=="usb",ENV{DEVTYPE}=="usb_device",ATTRS{idVendor}=="1df7",ATTRS{idProduct}=="3020",MODE:="0666"
+SUBSYSTEM=="usb",ENV{DEVTYPE}=="usb_device",ATTRS{idVendor}=="1df7",ATTRS{idProduct}=="3030",MODE:="0666"

--- a/install_sdrplay.sh
+++ b/install_sdrplay.sh
@@ -74,7 +74,7 @@ pushd /tmp/sdrplay
 
 if [ -d "/etc/udev/rules.d" ]; then
 	echo -n "Udev rules directory found, adding rules..."
-	cp -f 66-mirics.rules /etc/udev/rules.d/66-mirics.rules || exit 1
+	curl -s --location --output /etc/udev/rules.d/66-mirics.rules https://raw.githubusercontent.com/sdr-enthusiasts/install-libsdrplay/main/66-mirics.rules || exit 1
 	chmod 644 /etc/udev/rules.d/66-mirics.rules || exit 1
     echo "Done"
 else


### PR DESCRIPTION
in the new version of the SDR play api the file 66-mirics.rules is missing
provide and use the file from previous versions instead