### PR TITLE
let user disable sdrplay

### DIFF
--- a/s6-overlay/scripts/sdrplay.sh
+++ b/s6-overlay/scripts/sdrplay.sh
@@ -7,6 +7,11 @@ source /scripts/common
 SCRIPT_NAME="$(basename "$0")"
 SCRIPT_NAME="${SCRIPT_NAME%.*}"
 
+if [ -n "$NO_SDRPLAY_API" ]; then
+    sleep infinity
+    exit 0
+fi
+
 if [ -z "$SOAPYSDR" ] && [ -z "$SOAPYSDRDRIVER" ]; then
     sleep infinity
     exit 0


### PR DESCRIPTION
this shouldn't have any side effects for existing installs, but gives an extra option to disable the internal sdrplay api for e.g. multiple containers or running the api on the host